### PR TITLE
Addressed issue with 0 value packet id

### DIFF
--- a/lib/MQTT/Client.pm
+++ b/lib/MQTT/Client.pm
@@ -130,8 +130,12 @@ multi method retain (Str $topic, Str $message) {
 }
 
 method subscribe (Str $topic) returns Supply:D {
-    $!connection.write: mypack "C m/(C C n/a* C)", 0x82,
-        0, 0, $topic, 0;
+    state Int $packetID=1;
+    my $v= mypack "C m/(C C n/a* C)", 0x82, ($packetID +> 8)+& 0xFF, $packetID +& 0xFF, $topic, 1;
+    say $v;
+    $packetID++;
+    $packetID=1 if $packetID >= 65536;
+    $!connection.write: $v;
 
     my $regex = filter-as-regex($topic);
 

--- a/lib/MQTT/Client.pm
+++ b/lib/MQTT/Client.pm
@@ -132,7 +132,6 @@ multi method retain (Str $topic, Str $message) {
 method subscribe (Str $topic) returns Supply:D {
     state Int $packetID=1;
     my $v= mypack "C m/(C C n/a* C)", 0x82, ($packetID +> 8)+& 0xFF, $packetID +& 0xFF, $topic, 1;
-    say $v;
     $packetID++;
     $packetID=1 if $packetID >= 65536;
     $!connection.write: $v;


### PR DESCRIPTION
I had trouble subscribing to my mosquitto  server. Tracked down the
issue to MQTT 3.1.1 requiring a non 0 packet id in SUBSCRIBE message.

The id is only to be reused when the server acknowledges, however, in keeping
with the simple client idea, I made each subscription message use a new
id.