### PR TITLE
Adjust the default client-identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,8 @@
 {
     "perl": "6.*",
+    "raku": "6.*",
     "name": "MQTT::Client",
-    "version": "*",
+    "version": "0.0.2",
     "description": "Minimal MQTT v3 client interface",
     "author": "Juerd Waalboer",
     "provides": {

--- a/lib/MQTT/Client.pm
+++ b/lib/MQTT/Client.pm
@@ -6,7 +6,7 @@ use MQTT::Client::MyPack;
 
 has Int      $.keepalive-interval    is rw = 60;
 has Int      $.maximum-length        is rw = 2097152;  # 2 MB
-has Str      $.client-identifier     is rw = "perl6";
+has Str      $.client-identifier     is rw = "raku-" ~ $*PID.Str;
 has Str      $.server                is rw;
 has Int      $.port                  is rw = 1883;
 has Supply   $!messages;
@@ -56,6 +56,7 @@ method connect () {
         }
 
         my $initialized = $packets.grep(*.<type> == 2).head(1).Promise;
+
 
         $!connection.write: mypack "C m/(n/a* C C n n/a*)", 0x10,
             "MQIsdp", 3, 2, $!keepalive-interval, $!client-identifier;
@@ -131,7 +132,7 @@ multi method retain (Str $topic, Str $message) {
 
 method subscribe (Str $topic) returns Supply:D {
     $!connection.write: mypack "C m/(C C n/a* C)", 0x82,
-        0, 0, $topic, 0;
+        0, $topic.encode.bytes, $topic, 0;
 
     my $regex = filter-as-regex($topic);
 
@@ -269,7 +270,7 @@ handle, which may result in weird behaviour if the server sends out bad data.
 
 Most clients do not adhere to this part of the specifications.
 
-=back 
+=back
 
 =head1 LICENSE
 


### PR DESCRIPTION
It looks like ActiveMQ is quite happy with the empty string and makes a
broker generated id, whereas mosquitto doesn't appear to like it
regardless of the setting of the "clean-session" flag. So this is just
to stop surprising people like me.

Also set the remaining payload length in subscribe because it seems that
mosquitto doesn't like that not being set, ActiveMQ being perfectly happy.